### PR TITLE
Add 'remove points' button

### DIFF
--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -235,8 +235,7 @@
   []
   [:button
    {:class "mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect"
-    :on-click #(let []
-                 (rf/dispatch [:rm-points]))}
+    :on-click #(rf/dispatch [:rm-points])}
    "Remove Points"])
 
 ;; see [1] for an explanation. I'm not *sure* this pattern is required

--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -143,6 +143,11 @@
  (fn [db [_ eq]]
    (update-in db [:equations] conj {:equation eq :opacity 100})))
 
+(rf/reg-event-db
+ :rm-points
+ (fn [db _]
+   (assoc-in db [:points] [])))
+
 (rf/reg-event-fx
  :click
  (fn [{:keys [db] :as cofx} [_ coords]]
@@ -219,6 +224,14 @@
                   [:new-eq (fn [x] (+ (* a (.pow js/Math x b)) c))]))}
    "Add equation"])
 
+(defn remove-points-button
+  []
+  [:button
+   {:class "mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect"
+    :on-click #(let []
+                 (rf/dispatch [:rm-points]))}
+   "Remove Points"])
+
 ;; see [1] for an explanation. I'm not *sure* this pattern is required
 ;; here.
 ;; [1] https://github.com/Day8/re-frame/blob/master/docs/Using-Stateful-JS-Components.md
@@ -270,7 +283,8 @@
     [:div {:class "mdl-cell--12-col"}
      [:div
       [add-equation-button]
-      [toggle-animation-button]]
+      [toggle-animation-button]
+      [remove-points-button]]
      [:div {:style {:padding "16px"}}
       [plot-outer]]]]])
 

--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -231,6 +231,18 @@
       :on-click #(rf/dispatch [:toggle-animation])}
      text]))
 
+(defn add-equation-button
+  []
+  [:button
+   {:class "mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect"
+    :on-click #(let [a (- 2 (rand 4))
+                     b (+ 1 (rand-int 3))
+                     c (- 5 (rand 10))]
+                 (rf/dispatch
+                  ;; a * x^b + c
+                  [:new-eq (fn [x] (+ (* a (.pow js/Math x b)) c))]))}
+   "Add equation"])
+
 (defn remove-points-button
   []
   [:button
@@ -289,6 +301,7 @@
     [:div {:class "mdl-cell--12-col"}
      [:div
       [toggle-animation-button]
+      [add-equation-button]
       [remove-points-button]]
      [:div {:style {:padding "16px"}}
       [plot-outer]]]]])

--- a/src/equations/curve.clj
+++ b/src/equations/curve.clj
@@ -27,7 +27,7 @@
                        (some? x))
                   (= ch timeout-chan))
           (cond (= ch in-chan)
-                (println "got point" x)
+                (println "got message" x)
 
                 (= ch timeout-chan)
                 (do (println "timeout hit")


### PR DESCRIPTION
# What it does
 This PR adds a `Remove Points` button, which clears points from the canvas.  This PR fulfills https://github.com/probcomp/curve-fitting/issues/8

# How to test it
- start the server with `make dev`
- run `(go)` in your REPL and navigate to `localhost:3333`
- click on the canvas a few times
- click the `Remove Points` button to ensure points are cleared