### PR TITLE
Remove equation and animation buttons

### DIFF
--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -231,18 +231,6 @@
       :on-click #(rf/dispatch [:toggle-animation])}
      text]))
 
-(defn add-equation-button
-  []
-  [:button
-   {:class "mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect"
-    :on-click #(let [a (- 2 (rand 4))
-                     b (+ 1 (rand-int 3))
-                     c (- 5 (rand 10))]
-                 (rf/dispatch
-                  ;; a * x^b + c
-                  [:new-eq (fn [x] (+ (* a (.pow js/Math x b)) c))]))}
-   "Add equation"])
-
 (defn remove-points-button
   []
   [:button
@@ -301,7 +289,6 @@
     [:div {:class "mdl-cell--12-col"}
      [:div
       [toggle-animation-button]
-      [add-equation-button]
       [remove-points-button]]
      [:div {:style {:padding "16px"}}
       [plot-outer]]]]])

--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -103,7 +103,7 @@
  :initialize
  (fn [_ _]
    {:equations []
-    :animate false
+    :animate true
     :points []}))
 
 (defn re-trigger-timer []
@@ -211,6 +211,7 @@
  (fn [db _]
    (:points db)))
 
+;; views
 
 (defn remove-points-button
   []
@@ -236,6 +237,7 @@
       :component-did-mount
       (fn [comp]
         (let [g (make-graph)]
+          (re-trigger-timer)
           (reset! graph g)))
 
       :component-did-update

--- a/src/equations/canvas.cljs
+++ b/src/equations/canvas.cljs
@@ -194,15 +194,6 @@
    (js/console.error "Point post failure:" response)
    {}))
 
-(rf/reg-event-fx
- :toggle-animation
- (fn [cofx _]
-   (let [db        (:db cofx)
-         animating (:animate db)
-         disp      (if animating [] [:timer])]
-     {:db       (assoc db :animate (not animating))
-      :dispatch disp})))
-
 ;; queries / subs
 
 (rf/reg-sub
@@ -220,16 +211,6 @@
  (fn [db _]
    (:points db)))
 
-;; views
-
-(defn toggle-animation-button
-  []
-  (let [animate? @(rf/subscribe [:animate])
-        text (if animate? "Stop animation" "Start animation")]
-    [:button
-     {:class "mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect"
-      :on-click #(rf/dispatch [:toggle-animation])}
-     text]))
 
 (defn remove-points-button
   []
@@ -288,7 +269,6 @@
    [:div {:class "mdl-grid"}
     [:div {:class "mdl-cell--12-col"}
      [:div
-      [toggle-animation-button]
       [remove-points-button]]
      [:div {:style {:padding "16px"}}
       [plot-outer]]]]])


### PR DESCRIPTION
# What does this PR do?
This PR removes the `Toggle Animation` and `Add Equation` buttons, and automates the animation ("fading") of lines as they're drawn to the canvas.  This PR closes https://github.com/probcomp/curve-fitting/issues/7

# How do I test it?
You can test this PR by:
- Running `make dev` from the repo directory
- Running `(go)` after the server loads
- Navigating to `localhost:3333` in your browser
- Confirming that the buttons have been removed
- Waiting until lines are drawn automatically, then confirm that they fade automatically