### PR TITLE
Make points fully opaque

### DIFF
--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -40,7 +40,7 @@
             blue-value (int (- 255 red-value))
             pixel-x (inverted-x-scale point-x)
             pixel-y (inverted-y-scale point-y)]
-        (quil/fill red-value 0 blue-value 127)
+        (quil/fill red-value 0 blue-value 255)
         (quil/ellipse pixel-x
                       pixel-y
                       point-pixel-radius

--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -40,7 +40,7 @@
             blue-value (int (- 255 red-value))
             pixel-x (inverted-x-scale point-x)
             pixel-y (inverted-y-scale point-y)]
-        (quil/fill red-value 0 blue-value 192)
+        (quil/fill red-value 0 blue-value 127)
         (quil/ellipse pixel-x
                       pixel-y
                       point-pixel-radius


### PR DESCRIPTION
# What does this PR do?

This PR makes points fully opaque.  This closes https://github.com/probcomp/curve-fitting/issues/31

# How do I test this PR?

Run `make dev`, then `(go)`, and click on the resulting Quil app.  Make sure that - after clicking - points are shown and that, when you make overlapping points, the overlapping area is the same shade as the rest of each point.