### PR TITLE
Show curve count in bottom right corner

### DIFF
--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -60,11 +60,14 @@
   [curves pixel-width pixel-height]
   (let [curve-count (count curves)]
     (quil/rect-mode :corners)
-    (quil/text-align :center)
-    (quil/fill 59 22 228)
-    (quil/text
-      (str "Curves:\n" curve-count)
-      (- pixel-width 50) (- pixel-height 30) pixel-width pixel-height)))
+    (quil/text-align :right :bottom)
+    (quil/with-fill 0
+      (quil/text-size 14) ; pixels
+      (let [padding 5]
+        (quil/text
+         (str "curves: " curve-count)
+         (- pixel-width padding)
+         (- pixel-height padding))))))
 
 (defn draw!
   "Draws the given state onto the current sketch."

--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -55,14 +55,25 @@
         (quil/stroke 0 (opacity-scale score))
         (draw-plot f x-pixel-min x-pixel-max 10 x-scale y-scale)))))
 
+(defn draw-curve-count!
+  "Draws the number of curves in the bottom right-hand corner"
+  [curves pixel-width pixel-height]
+  (let [curve-count (count curves)]
+    (quil/rect-mode :corners)
+    (quil/text-align :center)
+    (quil/text
+      (str "Curves:\n" curve-count)
+      (- pixel-width 50) (- pixel-height 30) pixel-width pixel-height)))
+
 (defn draw!
   "Draws the given state onto the current sketch."
-  [{:keys [points curves]} x-scale y-scale pixel-width]
+  [{:keys [points curves]} x-scale y-scale pixel-width pixel-height]
   (let [inverted-x-scale (scales/invert x-scale)
         inverted-y-scale (scales/invert y-scale)
         x-pixel-max (int (/ pixel-width 2))
         x-pixel-min (* -1 x-pixel-max)]
     (quil/background 255)
+    (draw-curve-count! curves pixel-width pixel-height)
     (let [opacity-scale (constantly 255)]
       (draw-curves! curves
                     inverted-x-scale

--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -61,6 +61,7 @@
   (let [curve-count (count curves)]
     (quil/rect-mode :corners)
     (quil/text-align :center)
+    (quil/fill 59 22 228)
     (quil/text
       (str "Curves:\n" curve-count)
       (- pixel-width 50) (- pixel-height 30) pixel-width pixel-height)))

--- a/src/curve_fitting/sketches.clj
+++ b/src/curve_fitting/sketches.clj
@@ -19,7 +19,7 @@
 (defn applet
   [{:keys [anti-aliasing state pixel-width pixel-height x-scale y-scale]}]
   (applet/applet :size [pixel-width pixel-height]
-                 :draw (fn [_] (core/draw! @state x-scale y-scale pixel-width))
+                 :draw (fn [_] (core/draw! @state x-scale y-scale pixel-width pixel-height))
                  :mouse-pressed (fn [_ event] (swap! state #(mouse-pressed % x-scale y-scale event)))
                  :key-typed (fn [_ event] (swap! state #(key-typed % event)))
                  ;; Why :no-bind-output is necessary: https://github.com/quil/quil/issues/216


### PR DESCRIPTION
# What does this PR do?
This PR shows the number of lines on the canvas in the bottom right corner of the canvas.  This PR closes https://github.com/probcomp/curve-fitting/issues/36

I could see us wanting to style this with a certain color text (we currently use blue), and perhaps a constant background color behind the text to maintain legibility.  Please let me know if any of that should get added in this PR.

# How do I test this PR?
Start curve-fitting with `make dev`, and then - once in the REPL - `(go)`.  Confirm that you can see the number of curves in the bottom right-hand-corner -- the number should be constantly going up.  Click a few times and confirm the number gets reset before going up again.