### PR TITLE
Add a white border to points

### DIFF
--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -23,6 +23,14 @@
     (quil/curve-vertex x y))
   (quil/end-shape))
 
+(defn draw-point-borders
+  [pixel-x pixel-y]
+  "Draws a white border around a point to make it easier to distinguish between
+  points and lines."
+  (quil/fill 255 255 255 255)
+  (quil/ellipse
+    pixel-x pixel-y (+ 2 point-pixel-radius) (+ 2 point-pixel-radius)))
+
 (defn draw-clicked-points!
   "Draws the given points onto the current sketch."
   [points curves inverted-x-scale inverted-y-scale]
@@ -40,6 +48,7 @@
             blue-value (int (- 255 red-value))
             pixel-x (inverted-x-scale point-x)
             pixel-y (inverted-y-scale point-y)]
+        (draw-point-borders pixel-x pixel-y)
         (quil/fill red-value 0 blue-value 255)
         (quil/ellipse pixel-x
                       pixel-y


### PR DESCRIPTION
# What does this PR do?
This PR adds a white border to points, making it easier to distinguish between points and lines.  This PR closes https://github.com/probcomp/curve-fitting/issues/43

# How do I test this?
Run `make dev` to start a REPL, then run `(go)` to start Quil.  Click a few times to make points appear, and make sure that they have a slight white border around them to make it easier to distinguish between the points and lines.