### PR TITLE
Add settable maximum number of curves to be drawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Once you are running the application you can place points by clicking anywhere i
 ### Keyboard shortcuts
 
 - `c` will clear the screen.
-- Any other key will refresh the curves.
 - Digits followed by `return` will set the maximum number of curves.
+- Any other key will refresh the curves.

--- a/README.md
+++ b/README.md
@@ -25,5 +25,6 @@ Once you are running the application you can place points by clicking anywhere i
 
 ### Keyboard shortcuts
 
-- `backspace` will clear the screen.
+- `c` will clear the screen.
 - Any other key will refresh the curves.
+- Digits followed by `return` will set the maximum number of curves.

--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -65,7 +65,7 @@
 
 (defn draw-curve-count!
   "Draws the number of curves in the bottom right-hand corner"
-  [curves max-curves numbers pixel-width pixel-height]
+  [curves max-curves digits pixel-width pixel-height]
   (let [curve-count (count curves)]
     (quil/rect-mode :corners)
     (quil/text-align :right :bottom)
@@ -73,21 +73,21 @@
       (quil/text-size 14) ; pixels
       (let [padding 5]
         (quil/text
-         (str "curves: " curve-count "/" (if (seq numbers)
-                                           (str (apply str numbers) "_")
+         (str "curves: " curve-count "/" (if (seq digits)
+                                           (str (apply str digits) "_")
                                            max-curves))
          (- pixel-width padding)
          (- pixel-height padding))))))
 
 (defn draw!
   "Draws the given state onto the current sketch."
-  [{:keys [points curves max-curves numbers]} x-scale y-scale pixel-width pixel-height make-opacity-scale]
+  [{:keys [points curves max-curves digits]} x-scale y-scale pixel-width pixel-height make-opacity-scale]
   (let [inverted-x-scale (scales/invert x-scale)
         inverted-y-scale (scales/invert y-scale)
         x-pixel-max (int (/ pixel-width 2))
         x-pixel-min (* -1 x-pixel-max)]
     (quil/background 255)
-    (draw-curve-count! curves max-curves numbers pixel-width pixel-height)
+    (draw-curve-count! curves max-curves digits pixel-width pixel-height)
     (let [opacity-scale (make-opacity-scale (map :log-score curves))]
       (draw-curves! curves
                     inverted-x-scale

--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -29,7 +29,7 @@
   points and lines."
   (quil/fill 255 255 255 255)
   (quil/ellipse
-    pixel-x pixel-y (+ 2 point-pixel-radius) (+ 2 point-pixel-radius)))
+   pixel-x pixel-y (+ 2 point-pixel-radius) (+ 2 point-pixel-radius)))
 
 (defn draw-clicked-points!
   "Draws the given points onto the current sketch."
@@ -65,7 +65,7 @@
 
 (defn draw-curve-count!
   "Draws the number of curves in the bottom right-hand corner"
-  [curves pixel-width pixel-height]
+  [curves max-curves numbers pixel-width pixel-height]
   (let [curve-count (count curves)]
     (quil/rect-mode :corners)
     (quil/text-align :right :bottom)
@@ -73,19 +73,21 @@
       (quil/text-size 14) ; pixels
       (let [padding 5]
         (quil/text
-         (str "curves: " curve-count)
+         (str "curves: " curve-count "/" (if (seq numbers)
+                                           (str (apply str numbers) "_")
+                                           max-curves))
          (- pixel-width padding)
          (- pixel-height padding))))))
 
 (defn draw!
   "Draws the given state onto the current sketch."
-  [{:keys [points curves]} x-scale y-scale pixel-width pixel-height make-opacity-scale]
+  [{:keys [points curves max-curves numbers]} x-scale y-scale pixel-width pixel-height make-opacity-scale]
   (let [inverted-x-scale (scales/invert x-scale)
         inverted-y-scale (scales/invert y-scale)
         x-pixel-max (int (/ pixel-width 2))
         x-pixel-min (* -1 x-pixel-max)]
     (quil/background 255)
-    (draw-curve-count! curves pixel-width pixel-height)
+    (draw-curve-count! curves max-curves numbers pixel-width pixel-height)
     (let [opacity-scale (make-opacity-scale (map :log-score curves))]
       (draw-curves! curves
                     inverted-x-scale

--- a/src/curve_fitting/db.clj
+++ b/src/curve_fitting/db.clj
@@ -6,7 +6,7 @@
   []
   {:points     []
    :curves     []
-   :numbers    []
+   :digits     []
    :max-curves 20})
 
 (defn add-curve
@@ -31,25 +31,26 @@
   [state]
   (reset! state (init)))
 
-(defn add-number
-  "Add a number to the list of numbers."
+(defn add-digit
+  "Add a digit to the list of digits."
   [state raw-key]
-  (update state :numbers conj raw-key))
+  (update state :digits conj raw-key))
 
-(defn delete-number
-  "Deletes the last number from the list of numbers."
+(defn delete-digit
+  "Deletes the last digit from the list of digits."
   [state]
-  (update state :numbers (comp vec butlast)))
+  (update state :digits (comp vec butlast)))
 
-(defn- clear-numbers
+(defn- clear-digits
   "Clear the list of numbers."
   [state]
-  (assoc state :numbers []))
+  (assoc state :digits []))
 
 (defn set-max-curves
-  "Parse the list of numbers entered into an integer and set it as the number of max curves."
-  [{:keys [numbers] :as state}]
+  "Parse the list of digits entered into a number and set it as the maximum number
+  of curves."
+  [{:keys [digits] :as state}]
   (cond-> state
-    true (clear-numbers)
+    true (clear-digits)
     true (clear-curves)
-    (seq numbers) (assoc :max-curves (Integer/parseInt (apply str numbers)))))
+    (seq digits) (assoc :max-curves (Integer/parseInt (apply str digits)))))

--- a/src/curve_fitting/db.clj
+++ b/src/curve_fitting/db.clj
@@ -36,6 +36,11 @@
   [state raw-key]
   (update state :numbers conj raw-key))
 
+(defn delete-number
+  "Deletes the last number from the list of numbers."
+  [state]
+  (update state :numbers (comp vec butlast)))
+
 (defn- clear-numbers
   "Clear the list of numbers."
   [state]

--- a/src/curve_fitting/db.clj
+++ b/src/curve_fitting/db.clj
@@ -4,7 +4,10 @@
 (defn init
   "Returns the initial state for the sketch."
   []
-  {:points [], :curves []})
+  {:points     []
+   :curves     []
+   :numbers    []
+   :max-curves 20})
 
 (defn add-curve
   "Adds a curve to the sketch state."
@@ -27,3 +30,21 @@
   "Resets the sketch state to its initial value, clearing all points and curves."
   [state]
   (reset! state (init)))
+
+(defn add-number
+  "Add a number to the list of numbers."
+  [state raw-key]
+  (update state :numbers conj raw-key))
+
+(defn- clear-numbers
+  "Clear the list of numbers."
+  [state]
+  (assoc state :numbers []))
+
+(defn set-max-curves
+  "Parse the list of numbers entered into an integer and set it as the number of max curves."
+  [{:keys [numbers] :as state}]
+  (cond-> state
+    true (clear-numbers)
+    true (clear-curves)
+    (seq numbers) (assoc :max-curves (Integer/parseInt (apply str numbers)))))

--- a/src/curve_fitting/sketches.clj
+++ b/src/curve_fitting/sketches.clj
@@ -16,10 +16,10 @@
         (db/init)
 
         (contains? #{\0 \1 \2 \3 \4 \5 \6 \7 \8 \9} raw-key)
-        (db/add-number state raw-key)
+        (db/add-digit state raw-key)
 
         (= raw-key \backspace)
-        (db/delete-number state)
+        (db/delete-digit state)
 
         (= raw-key \newline)
         (db/set-max-curves state)

--- a/src/curve_fitting/sketches.clj
+++ b/src/curve_fitting/sketches.clj
@@ -11,13 +11,21 @@
     (db/add-point state [(x-scale x) (y-scale y)])))
 
 (defn key-typed
-  [state {:keys [raw-key]}]
-  (if (contains? #{\backspace} raw-key)
-    (db/init)
-    (db/clear-curves state)))
+  [state {:keys [raw-key] :as event}]
+  (cond (= raw-key \c)
+        (db/init)
+
+        (contains? #{\0 \1 \2 \3 \4 \5 \6 \7 \8 \9} raw-key)
+        (db/add-number state raw-key)
+
+        (= raw-key \newline)
+        (db/set-max-curves state)
+
+        :else (db/clear-curves state)))
 
 (defn applet
-  [{:keys [anti-aliasing state pixel-width pixel-height x-scale y-scale make-opacity-scale]}]
+  [{:keys [anti-aliasing state pixel-width pixel-height x-scale y-scale
+           make-opacity-scale max-curves]}]
   (applet/applet :size [pixel-width pixel-height]
                  :draw (fn [_] (core/draw! @state x-scale y-scale pixel-width pixel-height make-opacity-scale))
                  :mouse-pressed (fn [_ event] (swap! state #(mouse-pressed % x-scale y-scale event)))
@@ -36,11 +44,12 @@
         (when-not @stop?
           (let [{old-points :points :as old-val} @state
                 curve (sample-curve old-points)]
-            (swap! state (fn [{new-points :points :as new-val}]
+            (swap! state (fn [{new-points :points, curves :curves, max-curves :max-curves :as new-val}]
                            ;; Discard the curve if the points changed while
                            ;; we were working.
                            (cond-> new-val
-                             (= new-points old-points)
+                             (and (= new-points old-points)
+                                  (< (count curves) max-curves))
                              (db/add-curve curve)))))
           (recur)))
       (catch Exception e

--- a/src/curve_fitting/sketches.clj
+++ b/src/curve_fitting/sketches.clj
@@ -18,6 +18,9 @@
         (contains? #{\0 \1 \2 \3 \4 \5 \6 \7 \8 \9} raw-key)
         (db/add-number state raw-key)
 
+        (= raw-key \backspace)
+        (db/delete-number state)
+
         (= raw-key \newline)
         (db/set-max-curves state)
 

--- a/src/curve_fitting/sketches/prior.clj
+++ b/src/curve_fitting/sketches/prior.clj
@@ -6,7 +6,6 @@
 
 (defn sample-curve
   [points]
-  (Thread/sleep 100)
   (let [xs (map first points)
         ys (map second points)]
     (let [[_ trace log-score]


### PR DESCRIPTION
## What does this do?

Adds a maximum number of curves to be drawn to the application state. 

## How do I test this?

1. Start a REPL with `make dev`.
1. Start the application with `(go)`.
1. Observe that the bottom-right corner of the sketch quickly reads, "curves: 20/20".
1. Type `4` `0` `0`.
1. Observe that the bottom-right corner of the sketch reads "curves: 20/400_".
1. Type `BACKSPACE`.
1. Observe that the bottom-right corner of the sketch reads "curves: 20/40_".
1.  Type `RET`.
1. Observe that the sketch now simulates 40 new curves.