### PR TITLE
Remove num-curves in core.clj

### DIFF
--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -11,7 +11,6 @@
 
 (def text-padding 5) ; distance between text and scene border
 (def point-pixel-radius 8)
-(def num-curves 10)
 
 (defn draw-plot [f from to step inverted-x-scale inverted-y-scale]
   (quil/no-fill)


### PR DESCRIPTION
This PR removes an unused definition and closes https://github.com/probcomp/curve-fitting/issues/48