### PR TITLE
Add util namespace and move point drawing into it

### DIFF
--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -9,7 +9,8 @@
             [curve-fitting.inference :as inference]
             [curve-fitting.sketches.prior :as prior]
             [curve-fitting.sketches.resampling :as resampling]
-            [curve-fitting.scales :as scales]))
+            [curve-fitting.scales :as scales]
+            [curve-fitting.util.quil :as q-util]))
 
 (def text-padding 5) ; distance between text and scene border
 (def point-pixel-radius 8)
@@ -25,14 +26,6 @@
                                (inverted-y-scale y)]))))]
     (quil/curve-vertex x y))
   (quil/end-shape))
-
-(defn draw-point-borders
-  [pixel-x pixel-y]
-  "Draws a white border around a point to make it easier to distinguish between
-  points and lines."
-  (quil/fill 255 255 255 255)
-  (quil/ellipse
-   pixel-x pixel-y (+ 2 point-pixel-radius) (+ 2 point-pixel-radius)))
 
 (defn draw-clicked-points!
   "Draws the given points onto the current sketch."
@@ -51,7 +44,7 @@
             blue-value (int (- 255 red-value))
             pixel-x (inverted-x-scale point-x)
             pixel-y (inverted-y-scale point-y)]
-        (draw-point-borders pixel-x pixel-y)
+        (q-util/draw-point-borders pixel-x pixel-y point-pixel-radius)
         (quil/fill red-value 0 blue-value 255)
         (quil/ellipse pixel-x
                       pixel-y

--- a/src/curve_fitting/core.clj
+++ b/src/curve_fitting/core.clj
@@ -44,12 +44,11 @@
             blue-value (int (- 255 red-value))
             pixel-x (inverted-x-scale point-x)
             pixel-y (inverted-y-scale point-y)]
-        (q-util/draw-point-borders pixel-x pixel-y point-pixel-radius)
-        (quil/fill red-value 0 blue-value 255)
-        (quil/ellipse pixel-x
-                      pixel-y
-                      point-pixel-radius
-                      point-pixel-radius)))))
+        (q-util/draw-point! pixel-x
+                            pixel-y
+                            point-pixel-radius
+                            red-value
+                            blue-value)))))
 
 (defn draw-curves!
   "Draws the provided curves onto the current sketch."

--- a/src/curve_fitting/util/quil.clj
+++ b/src/curve_fitting/util/quil.clj
@@ -9,3 +9,13 @@
   (quil/fill 255 255 255 255)
   (quil/ellipse
    pixel-x pixel-y (+ 2 point-pixel-radius) (+ 2 point-pixel-radius)))
+
+(defn draw-point!
+  "Draws a point and its corresponding white border."
+  [pixel-x pixel-y point-pixel-radius red-value blue-value]
+  (draw-point-borders pixel-x pixel-y point-pixel-radius)
+  (quil/fill red-value 0 blue-value 255)
+  (quil/ellipse pixel-x
+                pixel-y
+                point-pixel-radius
+                point-pixel-radius))

--- a/src/curve_fitting/util/quil.clj
+++ b/src/curve_fitting/util/quil.clj
@@ -1,0 +1,11 @@
+(ns curve-fitting.util.quil
+  "Functioons for using Quil to draw points and lines."
+  (:require [quil.core :as quil]))
+
+(defn draw-point-borders
+  [pixel-x pixel-y point-pixel-radius]
+  "Draws a white border around a point to make it easier to distinguish between
+  points and lines."
+  (quil/fill 255 255 255 255)
+  (quil/ellipse
+   pixel-x pixel-y (+ 2 point-pixel-radius) (+ 2 point-pixel-radius)))


### PR DESCRIPTION
# What does this PR do?
This PR creates the `curve-fitting.util.quil` namespace, creates a function in it to draw a point, and refactors `core.clj` to use the utility namespace.  This PR closes https://github.com/probcomp/curve-fitting/issues/45

# How do I test this PR?
Run `make dev`, and then `(go)` once the REPL starts.  Click a few times to make sure that point drawing works the same way as it did before the refactor.