### PR TITLE
[WIP] Pick preset points from curve model

### DIFF
--- a/src/curve_fitting/model.clj
+++ b/src/curve_fitting/model.clj
@@ -34,7 +34,7 @@
                 (if (and outliers-enabled?
                          outlier-point?)
                   10
-                  1)))))
+                  0.01)))))
 
 (define curve-model
   (gen [xs]

--- a/src/curve_fitting/model.clj
+++ b/src/curve_fitting/model.clj
@@ -34,7 +34,7 @@
                 (if (and outliers-enabled?
                          outlier-point?)
                   10
-                  0.01)))))
+                  1)))))
 
 (define curve-model
   (gen [xs]

--- a/src/curve_fitting/model/trace.clj
+++ b/src/curve_fitting/model/trace.clj
@@ -22,6 +22,8 @@
 (def point-outlier-path '(0 "outlier-point?" "flip")) ; path from point subtrace to outlier choice
 (def outliers-enabled-path '(1 "add-noise-to-curve" 0 "outliers-enabled?" "flip")) ; path from root to outliers-enabled? choice
 
+(def coeffs-subtrace-path '(1 1 "generate-curve" 1 "coeffs" "replicate" "map"))
+
 ;; Cosntructors
 
 (defn point-subtrace
@@ -45,6 +47,7 @@
           (zipmap (range (count points))
                   points)))
 
+
 (defn points-trace
   "Returns a trace that fixes the model's outputs to `ys`."
   [ys]
@@ -55,6 +58,25 @@
   `outliers?`."
   [outliers?]
   (metaprob/trace-set (metaprob/empty-trace) outliers-enabled-path outliers?))
+
+(defn coefficients-trace
+  "Returns a trace that fixes the choice of coefficients."
+  [coefficients]
+
+  (reduce (fn [trace [i coeff]]
+            (metaprob/trace-set-subtrace
+             trace
+             (concat coeffs-subtrace-path (list i))
+             (-> (metaprob/empty-trace)
+                 (metaprob/trace-set
+                  '("f" "gaussian")
+                  coeff))))
+          (-> (outliers-trace false)
+              (metaprob/trace-set
+               '(1 1 "generate-curve" 0 "degree" "uniform-sample")
+               (count coefficients)))
+          (zipmap (range (count coefficients))
+                  coefficients)))
 
 ;; Points accessors
 

--- a/src/curve_fitting/point_sets.clj
+++ b/src/curve_fitting/point_sets.clj
@@ -1,95 +1,32 @@
 (ns curve-fitting.point-sets
   (:require
+   [metaprob.interpreters :as interpreters]
+   [curve-fitting.model :as model]
+   [curve-fitting.model.trace :as trace]
    [curve-fitting.scales :as scales]))
 
-(defn linear-points [x-min xs y-scale]
-  (let [point-count  (count xs)
-        y-min0       (:range-min y-scale)
-        y-max0       (:range-max y-scale)
-        y-indent     (/ (- y-max0 y-min0) 4)
-        y-min        (+ y-min0 y-indent)
-        y-max        (- y-max0 y-indent)
-        y-range      (- y-max y-min)
-        y-interval   (/ y-range (- point-count 1))]
-
-    (map-indexed (fn [ix x] {:x x :y (+ y-min (* y-interval ix))
-                             :selected false :outlier-mode :auto})
-                 xs)))
-
-(defn bump-points [x-min xs y-scale]
-  (let [point-count  (count xs)
-        y-min0       (:range-min y-scale)
-        y-max0       (:range-max y-scale)
-        y-indent-top (/ (- y-max0 y-min0) 50)
-        y-indent-bottom (/ (- y-max0 y-min0) 3)
-        y-min        (+ y-min0 y-indent-bottom)
-        y-max        (- y-max0 y-indent-top)
-
-        y-scale      (scales/->LinearScale 0 20 y-min y-max)
-        ys           [6 7 6 5 4 3 2 19 2 3]]
-
-    (map (fn [x y] {:x x :y (y-scale y)
-                    :selected false :outlier-mode :auto})
-                 xs ys)))
-
-(defn linear-points-outlier [x-min xs y-scale]
-  (let [points (vec (linear-points x-min xs y-scale))
-        y-outlier (/ (- (:range-max y-scale) (:range-min y-scale)) 10)
-        y-1    (- (get-in points [0 :y]) y-outlier)
-        y-8    (+ (get-in points [9 :y]) y-outlier)]
-    (-> points
-        (assoc-in [1 :y] y-8)
-        (assoc-in [8 :y] y-1))))
-
-(defn exp-points [point-count x-scale y-scale]
-  (let
-      [x-max0       (:range-max x-scale)
-       x-min0       (:range-min x-scale)
-       x-indent-l   (/ (- x-max0 x-min0) 50)
-       x-indent-r   (/ (- x-max0 x-min0) 3)
-       x-min        (+ x-min0 x-indent-l)
-       x-max        (- x-max0 x-indent-r)
-       x-range      (- x-max x-min)
-       x-interval   (/ x-range (- point-count 1))
-
-       y-min0       (:range-min y-scale)
-       y-max0       (:range-max y-scale)
-       y-indent-top (/ (- y-max0 y-min0) 50)
-       y-indent-bottom (/ (- y-max0 y-min0) 3)
-       y-min        (+ y-min0 y-indent-bottom)
-       y-max        (- y-max0 y-indent-top)
-
-       xs (map-indexed (fn [ix interval]
-                         (+ x-min (* ix interval)))
-                       (repeat 10 x-interval))
-
-       ys (map #(Math/pow (+ % (/ (- y-max0 y-min0) 2)) 2) xs)
-       y-scale (scales/->LinearScale (first ys) (last ys) y-min y-max)]
-
-    (map (fn [x y] {:x x :y (y-scale y)
-                    :selected false :outlier-mode :auto})
-         xs ys)))
+(def point-coeffs
+  [[0 0.5]
+   [0 1 0.5]])
 
 (defn next-point-set
   [state px-pt-scales]
-  (let [{x-px-pt :x, y-px-pt :y} px-pt-scales
-        point-count 10
-        point-set-ix (:point-set state)
 
-        x-max0       (:range-max x-px-pt)
-        x-min0       (:range-min x-px-pt)
-        x-indent     (/ (- x-max0 x-min0) 50)
-        x-min        (+ x-min0 x-indent)
-        x-max        (- x-max0 x-indent)
-        x-range      (- x-max x-min)
-        x-interval   (/ x-range (- point-count 1))
+  (let [point-set-ix (:point-set state)
+        {x-px-pt :x, y-px-pt :y} px-pt-scales
+        indent   (* 0.05 (scales/range-size x-px-pt))
+        indented-scale (scales/linear [0 9]
+                                      [(+ (:range-min x-px-pt) indent)
+                                       (- (:range-max x-px-pt) indent)])
+        xs       (map indented-scale (range 0 10))
+        coeffs   (point-coeffs point-set-ix)
+        [ys tr]  (interpreters/infer :procedure model/curve-model
+                                     :inputs [xs]
+                                     :intervention-trace (trace/coefficients-trace coeffs))]
 
-        xs (map-indexed (fn [ix interval]
-                          (+ x-min (* ix interval)))
-                        (repeat 10 x-interval))]
-    [(case point-set-ix
-       0 (linear-points x-min xs y-px-pt)
-       1 (linear-points-outlier x-min xs y-px-pt)
-       2 (exp-points point-count x-px-pt y-px-pt)
-       3 (bump-points x-min xs y-px-pt))
-     (mod (inc point-set-ix) 4)]))
+    ;; (clojure.pprint/pprint tr)
+
+    [(map (fn [x y] {:x x :y y
+                     :selected false :outlier-mode :auto})
+          xs ys)
+     (mod (inc point-set-ix) (count point-coeffs))]))

--- a/src/curve_fitting/point_sets.clj
+++ b/src/curve_fitting/point_sets.clj
@@ -7,7 +7,7 @@
 
 (def point-coeffs
   [[0 0.5]
-   [0 1 0.5]])
+   [5 5 0.5]])
 
 (defn next-point-set
   [state px-pt-scales]

--- a/src/curve_fitting/sketches.clj
+++ b/src/curve_fitting/sketches.clj
@@ -47,7 +47,9 @@
         (db/set-max-curves state)
 
         (= raw-key \p)
-        (db/set-points state (point-sets/next-point-set state px-pt-scales))
+        (db/set-points state (point-sets/next-point-set
+                              state
+                              px-pt-scales))
 
         :else (db/clear-curves state)))
 


### PR DESCRIPTION
This changes how we pick "canned" sets of points, to use our curve model with intervened degree and coefficients rather than hardcoded locations.

This demonstrates two curve sets- `y = 0.5x`, which approximates the 0th column in the NIPS "slide 21", and `y = 0.5x^2 + 2x`, which approximates the 2nd column on that slide. The other preset points have not yet been implemented.

As before, the sets can be cycled by pressing `p`.

Note that I significantly reduce the "inlier" noise value in `add-noise-to-curve`- it was set to 1, which resulted in points all over the place.

[WIP] can be removed once other point distributions are implemented.